### PR TITLE
Update required fields on trips resource

### DIFF
--- a/lib/hypertrack/api_operations/trip_api.rb
+++ b/lib/hypertrack/api_operations/trip_api.rb
@@ -20,7 +20,7 @@ module HyperTrack
       # Don't want to name this method as 'end'. Its a reserved keyword in Ruby.
       def end_trip(params)
         path = "end/"
-        self.update(path, params, [:end_location])
+        self.update(path, params, [])
       end
 
       def add_task(params)

--- a/lib/hypertrack/resources/trip.rb
+++ b/lib/hypertrack/resources/trip.rb
@@ -3,7 +3,7 @@ module HyperTrack
     include HyperTrack::ApiOperations::TripAPI
 
     API_BASE_PATH = "trips/"
-    REQUIRED_FIELDS = [:driver_id, :start_location, :tasks, :has_ordered_tasks]
+    REQUIRED_FIELDS = [:driver_id]
 
     VALID_ATTRIBUTE_VALUES = {
       vehicle_type: {

--- a/spec/lib/resources/trip_spec.rb
+++ b/spec/lib/resources/trip_spec.rb
@@ -14,22 +14,19 @@ describe HyperTrack::Trip do
     context "params missing one or all of required attributes" do
       it "should raise InvalidParameters error" do
         expect { HyperTrack::Trip.create({}) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id, :start_location, :tasks, :has_ordered_tasks]")
-
-        expect { HyperTrack::Trip.create({ driver_id: 'foo' }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:start_location, :tasks, :has_ordered_tasks]")
+        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id]")
 
         expect { HyperTrack::Trip.create({ start_location: { type: "Point", coordinates: [ 72.0, 19.0 ] } }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id, :tasks, :has_ordered_tasks]")
+        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id]")
 
         expect { HyperTrack::Trip.create({ tasks: ['task_id_1', 'task_id_2'] }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id, :start_location, :has_ordered_tasks]")
+        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id]")
 
         expect { HyperTrack::Trip.create({ has_ordered_tasks: true }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id, :start_location, :tasks]")
+        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id]")
 
         expect { HyperTrack::Trip.create({ driver_id: nil, tasks: ['task_id_1', 'task_id_2'] }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id, :start_location, :has_ordered_tasks]")
+        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:driver_id]")
       end
     end
 

--- a/spec/lib/resources/trip_spec.rb
+++ b/spec/lib/resources/trip_spec.rb
@@ -104,16 +104,6 @@ describe HyperTrack::Trip do
         to raise_error(HyperTrack::InvalidParameters, "Error: Expected a Hash. Got: ")
       end
     end
-
-    context "required params missing for #end_trip" do
-      it "should raise InvalidParameters error" do
-        expect { HyperTrack::Trip.new('trip_id', {}).end_trip({}) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:end_location]")
-
-        expect { HyperTrack::Trip.new('trip_id', {}).end_trip({ end_location: nil }) }.
-        to raise_error(HyperTrack::InvalidParameters, "Request is missing required params - [:end_location]")
-      end
-    end
   end
 
   describe "#add_task with invalid args" do

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module HyperTrack
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
API allows for trips without `tasks` or `start_location`